### PR TITLE
Require 'strscan' to be sure StringScanner will be present.

### DIFF
--- a/lib/websocket/extensions/parser.rb
+++ b/lib/websocket/extensions/parser.rb
@@ -1,3 +1,5 @@
+require 'strscan'
+
 module WebSocket
   class Extensions
 


### PR DESCRIPTION
I'm using [faye-weboscket-ruby](https://github.com/faye/faye-websocket-ruby) in [Garufa](https://github.com/Juanmcuello/garufa), a ruby websocket server. It recently started to fail with:

`NameError: uninitialized constant WebSocket::Extensions::Parser::StringScanner`

It seems that `websocket-extensions` is using `StringScanner` without requiring `strscan` first.

If `strscan` was not required first it fails like this:

```
irb(main):001:0> require 'websocket/extensions'
=> true
irb(main):002:0> WebSocket::Extensions::Parser.parse_header('str')
NameError: uninitialized constant WebSocket::Extensions::Parser::StringScanner
        from [...]/lib/websocket/extensions/parser.rb:23:in `parse_header'
        from (irb):2
        from /home/juan/.rbenv/versions/2.1.2/bin/irb:11:in `<main>'
irb(main):003:0> 
```

This PR simply requires 'strscan', which solves the problem.
