### PR TITLE
Fix deprecation warning about =~ being called on TrueClass.

### DIFF
--- a/lib/websocket/extensions/parser.rb
+++ b/lib/websocket/extensions/parser.rb
@@ -38,7 +38,7 @@ module WebSocket
             else
               data = true
             end
-            if data =~ NUMBER
+            if data != true and data =~ NUMBER
               data = data =~ /\./ ? data.to_f : data.to_i(10)
             end
 


### PR DESCRIPTION
With the code as it was, it will generate a warning like such:

.../websocket-extensions-0.1.3/lib/websocket/extensions/parser.rb:41:
warning: deprecated Object#=~ is called on TrueClass; it always returns
nil

So we will avoid if the variable is TrueClass.