### PR TITLE
Process message stacks without intermediate traversal allocations

### DIFF
--- a/lib/websocket/extensions.rb
+++ b/lib/websocket/extensions.rb
@@ -135,23 +135,25 @@ module WebSocket
     alias :valid_frame_rsv? :valid_frame_rsv
 
     def process_incoming_message(message)
-      @sessions.reverse.inject(message) do |msg, (ext, session)|
+      @sessions.reverse_each do |ext, session|
         begin
-          session.process_incoming_message(msg)
+          message = session.process_incoming_message(message)
         rescue => error
           raise ExtensionError, [ext.name, error.message].join(': ')
         end
       end
+      message
     end
 
     def process_outgoing_message(message)
-      @sessions.inject(message) do |msg, (ext, session)|
+      @sessions.each do |ext, session|
         begin
-          session.process_outgoing_message(msg)
+          message = session.process_outgoing_message(message)
         rescue => error
           raise ExtensionError, [ext.name, error.message].join(': ')
         end
       end
+      message
     end
 
     def close


### PR DESCRIPTION
## Summary

Traverse incoming sessions in reverse order without copying the array and carry the message through plain loops in both directions. Preserve error wrapping and pipeline order.

## Reproduction and verification

```ruby
# With active sessions a then b:
exts.process_outgoing_message(message) # a then b
exts.process_incoming_message(message) # b then a
```

Existing processing-order/error examples pass, plus 100 randomized selection/order scenarios. For 100,000 no-op messages through three sessions, incoming allocations fell from 300,001 to 1 and outgoing from 200,001 to 1; local times were 0.026354 to 0.015430s and 0.024441 to 0.014949s. These are synthetic local measurements, not production claims.

- Ruby 4.0.6 through rbenv; existing current-upstream suite: **64 examples, zero failures** on this isolated change.
- The cumulative release-based candidate passes **283 focused checks** (272 baseline failures → zero), **2,784 model checks**, the current upstream's 64-example suite, and gem build/extraction.
- The historical 0.1.5 suite has three Ruby keyword-versus-options-hash mock failures on both baseline and candidate. Current upstream already corrected those expectations; they were run against the candidate through an external preload without changing repository tests.
- No new or modified tests/specs, following the consumer repository's explicit policy. Reproductions/models were run from external scratch scripts.

## Breaking changes and limitations

No intended breaking change. The same message transformations, final return value and ExtensionError behavior remain; no extension API changes.

Only local Ruby 4.0.6/macOS execution is claimed; the repository's older Ruby/JRuby matrix needs upstream CI. No production access or unrelated release upgrades.
